### PR TITLE
fix(alumet-relay-server): use wget instead of nc in wait-for-influx initContainer

### DIFF
--- a/charts/alumet/Chart.yaml
+++ b/charts/alumet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -30,8 +30,8 @@ dependencies:
   condition: influxdb2.enabled
   repository: "https://helm.influxdata.com"
 - name: alumet-relay-server
-  version: 0.2.2
+  version: 0.2.3
   condition: alumet-relay-server.enabled
 - name: alumet-relay-client
-  version: 0.2.2
+  version: 0.2.3
   condition: alumet-relay-client.enabled

--- a/charts/alumet/charts/alumet-relay-client/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-client/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
+++ b/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
@@ -36,7 +36,8 @@ spec:
       # if relay_client plugin is activated, wait starting alumet server 
       initContainers:
         - name: wait-for-alumet-server
-          image: docker.io/busybox:latest
+          image: busybox:latest
+          imagePullPolicy: IfNotPresent
           command: [
             'sh',
             '-c',
@@ -48,7 +49,7 @@ spec:
         - name: alumet-relay-client
           image: {{ .Values.global.image.registry }}/alumet-agent:{{ .Values.image.version }}_{{ .Values.image.osVersion }}
           args: ["--config", "/etc/alumet/alumet-agent.toml"]          
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: "{{ .Values.resources.memory }}"

--- a/charts/alumet/charts/alumet-relay-client/values.yaml
+++ b/charts/alumet/charts/alumet-relay-client/values.yaml
@@ -139,5 +139,3 @@ plugins:
     buffer_timeout: 30s
   socket_control:
     enable: false
-
-

--- a/charts/alumet/charts/alumet-relay-server/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-server/templates/deployment.yaml
+++ b/charts/alumet/charts/alumet-relay-server/templates/deployment.yaml
@@ -19,11 +19,12 @@ spec:
       # activate init containers only when influxdb plugin is activated and if influxdb is deployed in this chart
       initContainers:
         - name: wait-for-influxdb
-          image: docker.io/busybox:latest
+          image: busybox:latest
+          imagePullPolicy: IfNotPresent
           command: [
             'sh',
             '-c',
-            'until nc -vz {{ .Release.Name }}-influxdb2 80; do echo "Waiting for influxdb service to be running"; sleep 2; done;'
+            'until wget -nv -t1 --spider "http://{{ .Release.Name }}-influxdb2:80/health"; do echo "Waiting for influxdb service to be running"; sleep 2; done;'
           ]
       {{- end }}
     {{- end }}
@@ -31,7 +32,7 @@ spec:
         - name: alumet-relay-server
           image: {{ .Values.global.image.registry }}/alumet-agent:{{ .Values.image.version }}_{{ .Values.image.osVersion }}
           args: ["--config", "/etc/alumet/alumet-agent.toml"]
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: "{{ .Values.resources.memory }}"


### PR DESCRIPTION
# Description

# PR check

Before merging this PR, I have verified that:

- [x] Updated the README if needed
- [x] Updated the README of every modified chart
- [x] Updated the version of the modified charts in Chart.yaml
