### PR TITLE
feat(prometheus-exporter): added support for prometheus exporter in s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ Refer to the github page <https://github.com/alumet-dev> for more details on ALU
 This helm chart contains the following subcharts:
 
 - influxdb: one pod and a service are deployed
-- ALUMET relay client: a pod is deployed on each cluster's node
+- ALUMET relay client: a pod is deployed on each cluster's node as a daemonset.
 - ALUMET relay server: one pod and a LoadBalancer service's type are deployed
 
 Each subcharts as its own values.yaml file and there is also a values.yaml for the main chart where we overwrite the default values related to subcharts.
+
+The chart has been tested with the Relay clients-server strategy and also with a client-only deployment exposing metrics via prometheus exporter consumed by a standard prometheus-kube-stack (the pod is annotatated with `prometheus.io/scrape: 'true'` so that it can be scrapped automatically).
+
 We defined also 2 global variables:
 
 - global.image.registry : All alumet docker images must be located on the same docker registry. This variable is used to set the URL path of the docker registry, the default value is: *ghrc.io/alumet-dev*
@@ -30,7 +33,7 @@ The secret's name is defined by this variable, it is not set by default.
 
 ## ALUMET relay server
 
-It receives the metrics by all ALUMET relay client and writes the metrics in the ouput plugin configured (CSV file, influxdb or mongodb).
+It receives the metrics by all ALUMET relay client and writes the metrics in the ouput plugin configured (CSV file, influxdb, mongodb, as a prometheus exporter or opentelemetry).
 The default configuration is correctly set-up to write in influxdb. The default value of helm variables related to alumet plugins are:
 
 - alumet-relay-server.plugins.influxdb.enable="true"
@@ -114,6 +117,8 @@ The default configuration is correctly set-up to allow communication between ALU
 - alumet-relay-client.plugins.rapl.enable="false"
 - alumet-relay-client.plugins.relay_client.enable="true"
 - alumet-relay-client.plugins.socket_control.enable="false"
+- alumet-relay-client.plugins.opentelemetry.enable="false"
+- alumet-relay-client.plugins.prometheusExporter.enable="false"
 
 relay client configuration file is created as a config map named: *\<release name\>-alumet-relay-client-config*
 

--- a/charts/alumet/Chart.yaml
+++ b/charts/alumet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -30,8 +30,8 @@ dependencies:
   condition: influxdb2.enabled
   repository: "https://helm.influxdata.com"
 - name: alumet-relay-server
-  version: 0.2.3
+  version: 0.2.4
   condition: alumet-relay-server.enabled
 - name: alumet-relay-client
-  version: 0.2.3
+  version: 0.2.4
   condition: alumet-relay-client.enabled

--- a/charts/alumet/charts/alumet-relay-client/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-client/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
+++ b/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
@@ -118,3 +118,22 @@ max_delay = "4s"
 [plugins.socket-control]
 enable = {{ .Values.plugins.socket_control.enable }}
 socket_path = "alumet-control.sock"
+
+[plugins.opentelemetry]
+enable = {{ .Values.plugins.opentelemetry.enable }}
+collector_host = "http://localhost:4317"
+prefix = ""
+suffix = ""
+append_unit_to_metric_name = false
+use_unit_display_name = true
+add_attributes_to_labels = true
+
+[plugins.prometheus-exporter]
+enable = {{ .Values.plugins.prometheusExporter.enable }}
+host = "0.0.0.0"
+prefix = ""
+suffix = "_alumet"
+port = 9091
+append_unit_to_metric_name = false
+use_unit_display_name = true
+add_attributes_to_labels = true

--- a/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
+++ b/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
@@ -2,14 +2,16 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "alumet-relay-client.fullname" . }}
-
-  
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: alumet-relay-client
   template:
     metadata:
+      {{- if .Values.plugins.prometheusExporter.enable }}
+      annotations:
+        prometheus.io/scrape: 'true'
+      {{ end }}
       labels:
         {{ include "alumet-relay-client.labels" . | nindent 8 }}
     spec:
@@ -61,7 +63,11 @@ spec:
             - name: config
               mountPath: /etc/alumet/alumet-agent.toml
               subPath: config
-
+          {{- if .Values.plugins.prometheusExporter.enable }}
+          ports:
+            - containerPort: {{ .Values.plugins.prometheusExporter.port }}
+              name: "exporter"
+          {{ end }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/alumet/charts/alumet-relay-client/templates/service.yaml
+++ b/charts/alumet/charts/alumet-relay-client/templates/service.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.plugins.prometheusExporter.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "alumet-relay-client.fullname" . }}
+spec:
+  type: ClusterIP
+  selector:
+    app: alumet-relay-client
+  ports:
+    - port: {{ .Values.plugins.prometheusExporter.port }}
+      name: "exporter"
+{{ end }}

--- a/charts/alumet/charts/alumet-relay-client/values.yaml
+++ b/charts/alumet/charts/alumet-relay-client/values.yaml
@@ -139,3 +139,8 @@ plugins:
     buffer_timeout: 30s
   socket_control:
     enable: false
+  opentelemetry:
+    enable: false
+  prometheusExporter:
+    enable: false
+    port: 9091

--- a/charts/alumet/charts/alumet-relay-server/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-server/templates/deployment.yaml
+++ b/charts/alumet/charts/alumet-relay-server/templates/deployment.yaml
@@ -10,6 +10,10 @@ spec:
       app: alumet-relay-server
   template:
     metadata:
+      {{- if .Values.plugins.prometheusExporter.enable }}
+      annotations:
+        prometheus.io/scrape: 'true'
+      {{ end }}
       labels:
         app: alumet-relay-server
         {{ include "alumet-relay-server.labels" . | nindent 8 }}
@@ -47,6 +51,7 @@ spec:
             - name: RUST_BACKTRACE
               value: "{{ .Values.env.RUST_BACKTRACE }}"
             - name: INFLUX_TOKEN
+              {{- if .Values.plugins.influxdb.enable }}
               valueFrom:
                 secretKeyRef:
                   {{- if .Values.plugins.influxdb.existingSecret }}
@@ -56,8 +61,16 @@ spec:
                   name: {{ .Release.Name }}-influxdb2-auth
                   {{- end }}
                   key: admin-token
+              {{- else }}
+              value: "not-needed"
+              {{- end }}
           ports:
             - containerPort: {{ .Values.service.port }}
+              name: relay
+            {{- if .Values.plugins.prometheusExporter.enable }}
+            - containerPort: {{ .Values.plugins.prometheusExporter.port }}
+              name: "exporter"
+            {{ end }}
           securityContext:
             capabilities:
               add: [{{ .Values.securityContext.capabilities }}]

--- a/charts/alumet/charts/alumet-relay-server/templates/deployment.yaml
+++ b/charts/alumet/charts/alumet-relay-server/templates/deployment.yaml
@@ -50,8 +50,8 @@ spec:
               value: "{{ .Values.env.RUST_LOG }}"
             - name: RUST_BACKTRACE
               value: "{{ .Values.env.RUST_BACKTRACE }}"
+            {{- if .Values.plugins.influxdb.enable }}
             - name: INFLUX_TOKEN
-              {{- if .Values.plugins.influxdb.enable }}
               valueFrom:
                 secretKeyRef:
                   {{- if .Values.plugins.influxdb.existingSecret }}
@@ -60,10 +60,8 @@ spec:
                   # use the default secret created by influxdb
                   name: {{ .Release.Name }}-influxdb2-auth
                   {{- end }}
-                  key: admin-token
-              {{- else }}
-              value: "not-needed"
-              {{- end }}
+                  key: admin-toke
+            {{- end }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: relay

--- a/charts/alumet/charts/alumet-relay-server/templates/deployment.yaml
+++ b/charts/alumet/charts/alumet-relay-server/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
                   # use the default secret created by influxdb
                   name: {{ .Release.Name }}-influxdb2-auth
                   {{- end }}
-                  key: admin-toke
+                  key: admin-token
             {{- end }}
           ports:
             - containerPort: {{ .Values.service.port }}

--- a/charts/alumet/charts/alumet-relay-server/templates/service.yaml
+++ b/charts/alumet/charts/alumet-relay-server/templates/service.yaml
@@ -8,3 +8,8 @@ spec:
     app: alumet-relay-server
   ports:
     - port: {{ .Values.service.port }}
+      name: "relay"
+    {{- if .Values.plugins.prometheusExporter.enable }}
+    - port: {{ .Values.plugins.prometheusExporter.port }}
+      name: "exporter"
+    {{ end }}

--- a/charts/alumet/charts/alumet-relay-server/values.yaml
+++ b/charts/alumet/charts/alumet-relay-server/values.yaml
@@ -111,6 +111,7 @@ plugins:
 
   prometheusExporter:
     enable: false
+    port: 9091
   
   
   

--- a/charts/alumet/values.yaml
+++ b/charts/alumet/values.yaml
@@ -18,7 +18,6 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-
  
 alumet-relay-server:
   enabled: true
@@ -40,7 +39,6 @@ influxdb2:
     bucket: default
     organization: "influxdata"
   existingSecret: ""
-
 
 global:
   image:


### PR DESCRIPTION
# Description

fixes for 0.2.3 and support for prometheus-exporter

I deployed in two scenarios:

relay server + relay client with only te server exposing the metrics
relay client only. This is the way in which we are going to use Alumet in funded project since we already have a monitoring stack that scrapes metrics per-node and provides re-labeling and adds more information to the metrics.

# PR check

Before merging this PR, I have verified that:

- [x] Updated the README if needed
- [x] Updated the README of every modified chart
- [x] Updated the version of the modified charts in Chart.yaml
