### PR TITLE
Feat/deployment client only

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ kubectl  -n <namesapce> create  secret docker-registry gh-registry-secret --dock
 ```
 
 ```text
-helm test-alumet alumet --namespace test --set influxdb2.persistence.enabled=false --set global.secret=gh-registry-secret
+helm install test-alumet alumet --namespace test --set influxdb2.persistence.enabled=false --set global.secret=gh-registry-secret
 NAME: test-alumet
 LAST DEPLOYED: Wed Jan 22 09:35:29 2025
 NAMESPACE: test
@@ -202,7 +202,6 @@ List of pods and services running:
 ```text
 local@master:$ kubectl -n test get pod
 NAME                                               READY   STATUS                  RESTARTS   AGE
-mongodb-6d6fc5d86f-pttb5                           1/1     Running                 0          19d
 test-alumet-alumet-relay-client-6ssmd              1/1     Running                 0          56s
 test-alumet-alumet-relay-client-h4ntl              1/1     Running                 0          56s
 test-alumet-alumet-relay-client-hsgdl              1/1     Running                 0          56s

--- a/charts/alumet/Chart.yaml
+++ b/charts/alumet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,5 +33,5 @@ dependencies:
   version: 0.2.6
   condition: alumet-relay-server.enabled
 - name: alumet-relay-client
-  version: 0.2.6
+  version: 0.2.7
   condition: alumet-relay-client.enabled

--- a/charts/alumet/charts/alumet-relay-client/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-client/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
+++ b/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
@@ -106,11 +106,7 @@ no_perf_events = false
 [plugins.relay-client]
 enable = {{ .Values.plugins.relay_client.enable }}
 client_name = "${NODE_NAME}"
-{{- if .Values.plugins.relay_client.relay_server }}
-relay_server = "{{ .Values.plugins.relay_client.relay_server }}:{{ .Values.plugins.relay_client.port }}" 
-{{- else }}
-relay_server = "{{ .Release.Name }}-alumet-relay-server:{{ .Values.plugins.relay_client.port }}"
-{{- end }}
+relay_server = "{{ .Values.plugins.relay_client.relay_server | default (printf "%s-alumet-relay-server" .Release.Name ) }}:{{ .Values.plugins.relay_client.port }}"
 buffer_max_length = {{ .Values.plugins.relay_client.buffer_max_length }}
 buffer_timeout = "{{ .Values.plugins.relay_client.buffer_timeout }}"
 

--- a/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
+++ b/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
@@ -106,7 +106,11 @@ no_perf_events = false
 [plugins.relay-client]
 enable = {{ .Values.plugins.relay_client.enable }}
 client_name = "${NODE_NAME}"
+{{- if .Values.plugins.relay_client.relay_server }}
+relay_server = "{{ .Values.plugins.relay_client.relay_server }}:{{ .Values.plugins.relay_client.port }}" 
+{{- else }}
 relay_server = "{{ .Release.Name }}-alumet-relay-server:{{ .Values.plugins.relay_client.port }}"
+{{- end }}
 buffer_max_length = {{ .Values.plugins.relay_client.buffer_max_length }}
 buffer_timeout = "{{ .Values.plugins.relay_client.buffer_timeout }}"
 

--- a/charts/alumet/charts/alumet-relay-client/templates/configmap.yaml
+++ b/charts/alumet/charts/alumet-relay-client/templates/configmap.yaml
@@ -5,6 +5,6 @@ kind: ConfigMap
 metadata:
   name: {{ template "alumet-relay-client.fullname" . }}-config
 data:
-  config: |
+  config: |-
     {{- (tpl (.Files.Get "alumet-agent.toml" ) .) | nindent 8 }}
 {{- end }}

--- a/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
+++ b/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
@@ -43,7 +43,11 @@ spec:
           command: [
             'sh',
             '-c',
+            {{- if .Values.plugins.relay_client.relay_server }}
+            'until nc -vz {{ .Values.plugins.relay_client.relay_server }} {{ .Values.plugins.relay_client.port }}; do echo "Waiting for alumet-relay-server to be running"; sleep 2; done;'
+            {{- else }}
             'until nc -vz {{ .Release.Name }}-alumet-relay-server {{ .Values.plugins.relay_client.port }}; do echo "Waiting for alumet-relay-server to be running"; sleep 2; done;'
+            {{- end }}
           ]
     {{- end }}   
 

--- a/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
+++ b/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
@@ -43,11 +43,7 @@ spec:
           command: [
             'sh',
             '-c',
-            {{- if .Values.plugins.relay_client.relay_server }}
-            'until nc -vz {{ .Values.plugins.relay_client.relay_server }} {{ .Values.plugins.relay_client.port }}; do echo "Waiting for alumet-relay-server to be running"; sleep 2; done;'
-            {{- else }}
-            'until nc -vz {{ .Release.Name }}-alumet-relay-server {{ .Values.plugins.relay_client.port }}; do echo "Waiting for alumet-relay-server to be running"; sleep 2; done;'
-            {{- end }}
+            'until nc -vz {{ .Values.plugins.relay_client.relay_server | default (printf "%s-alumet-relay-server" .Release.Name) }} {{ .Values.plugins.relay_client.port }}; do echo "Waiting for alumet-relay-server to be running"; sleep 2; done;'                  
           ]
     {{- end }}   
 

--- a/charts/alumet/charts/alumet-relay-client/values.yaml
+++ b/charts/alumet/charts/alumet-relay-client/values.yaml
@@ -133,8 +133,8 @@ plugins:
     enable: false
   relay_client:
     enable: true
-    client_name: alumet-client
     port: 50051
+    relay_server:
     buffer_max_length: 200
     buffer_timeout: 30s
   socket_control:


### PR DESCRIPTION
# Description
Add new helm variable (plugins.relay_client.relay_server) to be able to deploy only alumet client and connect it ti an existing alumet server.
Fix a minor error in README related to a list of pods (remove undesired pod in the output of kubectl get pod command)

# PR check

Before merging this PR, I have verified that:

- [ ] Updated the README if needed
- [ ] Updated the README of every modified chart
- [ ] Updated the version of the modified charts in Chart.yaml
