### PR TITLE
fix(attribution-plugin): retention aligned with flush interval

### DIFF
--- a/charts/alumet/Chart.yaml
+++ b/charts/alumet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,5 +33,5 @@ dependencies:
     version: 0.6.0
     condition: alumet-relay-server.enabled
   - name: alumet-relay-client
-    version: 0.6.0
+    version: 0.6.1
     condition: alumet-relay-client.enabled

--- a/charts/alumet/charts/alumet-relay-client/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-client/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
+++ b/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
@@ -107,10 +107,10 @@ enable = {{ .Values.plugins.energyAttribution.enable }}
 expr = "cpu_energy * cpu_usage / 100.0"
 ref = "cpu_energy"
 # The duration the measurement points are kept in memory before being dropped.
-# This need to be coherent with the poll_interval of the metrics involved in this formula.
-# Eg: If the metrics come from sources that poll every 1 second, it's recommanded to define the retention_time to at least 2 seconds.
+# This need to be coherent with the poll_interval/flush_interval of the metrics involved in this formula.
+# Eg: If the metrics come from sources poll/flush every 1 second, it's recommanded to define the retention_time to at least 2 seconds.
 # This way the plugin can make use of the precedent values of this metric to make interpolations.
-{{ $poll := trimSuffix "s" .Values.plugins.rapl.poll_interval | int -}}
+{{ $poll := trimSuffix "s" .Values.plugins.rapl.flush_interval | int -}}
 {{- $new_poll := add $poll 1 -}}
 retention_time = "{{ $new_poll }}s"
 
@@ -135,8 +135,8 @@ cpu_usage = { metric = "cpu_percent", kind = "total" }
 expr = "cpu_energy * cpu_usage / 100.0"
 ref = "cpu_energy"
 # The duration the measurement points are kept in memory before being dropped.
-# This need to be coherent with the poll_interval of the metrics involved in this formula.
-# Eg: If the metrics come from sources that poll every 1 second, it's recommanded to define the retention_time to at least 2 seconds.
+# This need to be coherent with the poll_interval/flush_interval of the metrics involved in this formula.
+# Eg: If the metrics come from sources that poll/flush every 1 second, it's recommanded to define the retention_time to at least 2 seconds.
 # This way the plugin can make use of the precedent values of this metric to make interpolations.
 retention_time = "6s"
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
# Description

attribution plugin needs to behigher than the update interval in the measurement buffer which is decided by flush_interval in teh case of rapl, not the poll_interval

# PR check

Before merging this PR, I have verified that:

- [x] Updated the README if needed
- [x] Updated the values.yaml of every modified chart
- [ ] Updated the version of the modified charts in Chart.yaml
