### PR TITLE
feat(alumet-relay-client): pod is now privileged and hostPID is now used

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ To create the config map:
 kubectl create cm <config map name> --from-file=config=alumet-agent-client.toml
 ```
 
+### Using process-to-cgroup-bridge plugin
+
+The process-to-cgroup-bridge find the associated cgroup to a process.
+This plugin needs access to PIDs below `/proc/`. The key *hostPID* allows the pod to share the PID namespace, allowing the plugin to access other processes executed on the node.
+
 ### Using the nvml plugin
 
 When enabling the nvml plugin through the values, the chart automatically appends a limits of `nvidia.com/gpu` to `1`.

--- a/charts/alumet/Chart.yaml
+++ b/charts/alumet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,5 +33,5 @@ dependencies:
     version: 0.6.2
     condition: alumet-relay-server.enabled
   - name: alumet-relay-client
-    version: 0.6.3
+    version: 0.7.0
     condition: alumet-relay-client.enabled

--- a/charts/alumet/charts/alumet-relay-client/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-client/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
+++ b/charts/alumet/charts/alumet-relay-client/templates/daemonset.yaml
@@ -17,9 +17,6 @@ spec:
       labels:
         {{ include "alumet-relay-client.labels" . | nindent 8 }}
     spec:
-      securityContext:
-        # for RAPL plugin we need to be root
-        runAsUser: 0
       tolerations:
         {{ toYaml .Values.tolerations | nindent 8 }}
       {{- if .Values.runtimeClassName }}
@@ -27,6 +24,9 @@ spec:
       {{- end }}
       serviceAccountName: {{ .Release.Name }}-alumet-reader
       automountServiceAccountToken: true
+      {{- if .Values.hostPID }}
+      hostPID: {{ .Values.hostPID }}
+      {{- end }}
       {{- if .Values.plugins.relay_client.enable }}
       # if relay_client plugin is activated, wait starting alumet server
       initContainers:

--- a/charts/alumet/charts/alumet-relay-client/values.yaml
+++ b/charts/alumet/charts/alumet-relay-client/values.yaml
@@ -4,12 +4,9 @@ fullnameOverride: ''
 runtimeClassName: ''
 
 securityContext:
-  capabilities:
-    add:
-      - SYS_ADMIN
-      - SYS_NICE
-      - PERFMON
-      - SYS_PTRACE
+  privileged: true
+
+hostPID: true
 
 resources:
   limits:


### PR DESCRIPTION
<!-- markdownlint-disable -->
# Description

Make the pod related to daemonset client privileged and use hostpid to make the pod able to gather correct PID

Fix: https://github.com/alumet-dev/alumet/issues/398
# PR check

Before merging this PR, I have verified that:

- [ ] Updated the README if needed
- [ ] Updated the values.yaml of every modified chart
- [ ] Updated the version of the modified charts in Chart.yaml
