### PR TITLE
fix(k8s plugin): add allow_container parameter to k8s plugin

### DIFF
--- a/charts/alumet/Chart.yaml
+++ b/charts/alumet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,5 +33,5 @@ dependencies:
     version: 0.6.2
     condition: alumet-relay-server.enabled
   - name: alumet-relay-client
-    version: 0.7.0
+    version: 0.7.1
     condition: alumet-relay-client.enabled

--- a/charts/alumet/charts/alumet-relay-client/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-client/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
+++ b/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
@@ -39,6 +39,7 @@ k8s_api_url = "https://kubernetes.default.svc:443"
 k8s_node = "${NODE_NAME}"
 token_retrieval = "file"
 annotate_foreign_measurements = false
+annotate_containers = true
 
 [plugins.nvml]
 enable = {{ .Values.plugins.nvml.enable }}


### PR DESCRIPTION
<!-- markdownlint-disable -->
# Description

Previously forgot to add by default this argument which allow the plugin to look at pod level even w/ a container level cgroup

# PR check

Before merging this PR, I have verified that:

- [ ] Updated the README if needed
- [ ] Updated the values.yaml of every modified chart
- [ ] Updated the version of the modified charts in Chart.yaml
