### PR TITLE
fix: issue-53, reorder k8s plugin after process-to-cgroup-bridge

### DIFF
--- a/charts/alumet/Chart.yaml
+++ b/charts/alumet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,5 +33,5 @@ dependencies:
     version: 0.7.0
     condition: alumet-relay-server.enabled
   - name: alumet-relay-client
-    version: 0.8.0
+    version: 0.8.1
     condition: alumet-relay-client.enabled

--- a/charts/alumet/charts/alumet-relay-client/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-client/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
+++ b/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
@@ -102,9 +102,12 @@ ref = "cpu_energy"
 # This need to be coherent with the poll_interval/flush_interval of the metrics involved in this formula.
 # Eg: If the metrics come from sources poll/flush every 1 second, it's recommanded to define the retention_time to at least 2 seconds.
 # This way the plugin can make use of the precedent values of this metric to make interpolations.
-{{ $poll := trimSuffix "s" .Values.plugins.rapl.flush_interval | int -}}
+{{- $val := .Values.plugins.rapl.flush_interval | toString }}
+{{- $lastChar := substr (int (sub (len $val) 1)) (int (len $val)) $val }}
+{{ $poll := trimSuffix $lastChar .Values.plugins.rapl.flush_interval | int -}}
 {{- $new_poll := add $poll 1 -}}
-retention_time = "{{ $new_poll }}s"
+
+retention_time = "{{ $new_poll }}{{ $lastChar }}"
 
 # Timeseries related to the resources.
 [plugins.energy-attribution.formulas.attributed_rapl_energy.per_resource]
@@ -154,9 +157,12 @@ ref = "gpu_energy"
 # This need to be coherent with the poll_interval/flush_interval of the metrics involved in this formula.
 # Eg: If the metrics come from sources poll/flush every 1 second, it's recommanded to define the retention_time to at least 2 seconds.
 # This way the plugin can make use of the precedent values of this metric to make interpolations.
-{{ $poll := trimSuffix "s" .Values.plugins.nvml.flush_interval | int -}}
+{{- $val := .Values.plugins.nvml.flush_interval | toString }}
+{{- $lastChar := substr (int (sub (len $val) 1)) (int (len $val)) $val }}
+{{ $poll := trimSuffix $lastChar .Values.plugins.nvml.flush_interval | int -}}
 {{- $new_poll := add $poll 1 -}}
-retention_time = "{{ $new_poll }}s"
+
+retention_time = "{{ $new_poll }}{{ $lastChar }}"
 
 [plugins.energy-attribution.formulas.attributed_nvml_energy.per_resource]
 gpu_energy = { metric = "nvml_energy_consumption", resource_kind = "gpu" }

--- a/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
+++ b/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
@@ -32,19 +32,10 @@ enable = {{ .Values.plugins.jetson.enable }}
 poll_interval = "1s"
 flush_interval = "5s"
 
-[plugins.k8s]
-enable = {{ .Values.plugins.k8s.enable }}
-poll_interval = "{{ .Values.plugins.k8s.poll_interval }}"
-k8s_api_url = "https://kubernetes.default.svc:443"
-k8s_node = "${NODE_NAME}"
-token_retrieval = "file"
-annotate_foreign_measurements = false
-annotate_containers = true
-
 [plugins.nvml]
 enable = {{ .Values.plugins.nvml.enable }}
-poll_interval = "1s"
-flush_interval = "5s"
+poll_interval = "{{ .Values.plugins.nvml.poll_interval }}"
+flush_interval = "{{ .Values.plugins.nvml.flush_interval }}"
 skip_failed_devices = true
 mode = "{{ .Values.plugins.nvml.mode }}"
 
@@ -159,7 +150,13 @@ cpu_usage = { metric = "cpu_percent", kind = "total" }
 [plugins.energy-attribution.formulas.attributed_nvml_energy]
 expr = "(gpu_energy/1000) * (gpu_usage/100.0)" # gpu_energy are mJ
 ref = "gpu_energy"
-retention_time = "6s"
+# The duration the measurement points are kept in memory before being dropped.
+# This need to be coherent with the poll_interval/flush_interval of the metrics involved in this formula.
+# Eg: If the metrics come from sources poll/flush every 1 second, it's recommanded to define the retention_time to at least 2 seconds.
+# This way the plugin can make use of the precedent values of this metric to make interpolations.
+{{ $poll := trimSuffix "s" .Values.plugins.nvml.flush_interval | int -}}
+{{- $new_poll := add $poll 1 -}}
+retention_time = "{{ $new_poll }}s"
 
 [plugins.energy-attribution.formulas.attributed_nvml_energy.per_resource]
 gpu_energy = { metric = "nvml_energy_consumption", resource_kind = "gpu" }
@@ -175,6 +172,15 @@ merge_similar_cgroups = true
 # Will keep all the measurements that have been processed by the transformer. In case it's false only the measurements with a cgroup resource consumer will be kept.
 keep_processed_measurements = false
 {{- end }}
+
+[plugins.k8s]
+enable = {{ .Values.plugins.k8s.enable }}
+poll_interval = "{{ .Values.plugins.k8s.poll_interval }}"
+k8s_api_url = "https://kubernetes.default.svc:443"
+k8s_node = "${NODE_NAME}"
+token_retrieval = "file"
+annotate_foreign_measurements = true
+annotate_containers = true
 
 [plugins.relay-client]
 enable = {{ .Values.plugins.relay_client.enable }}

--- a/charts/alumet/charts/alumet-relay-client/values.yaml
+++ b/charts/alumet/charts/alumet-relay-client/values.yaml
@@ -58,6 +58,8 @@ plugins:
     poll_interval: 5s
   nvml:
     enable: false
+    poll_interval: 1s
+    flush_interval: 5s
     mode: full
   oar:
     enable: false


### PR DESCRIPTION
<!-- markdownlint-disable -->
# Description

- Fix issue #53:  reorder k8s plugin after process-to-cgroup-bridge,
- add 2 parameters: plugins.nvml.poll_interval, plugins.nvml.flush_interval, 
- calculate retention_time value using plugins.nvml.flush_interval


# PR check

Before merging this PR, I have verified that:

- [ ] Updated the README if needed
- [ ] Updated the values.yaml of every modified chart
- [ ] Updated the version of the modified charts in Chart.yaml
