### PR TITLE
fix: issue-53, compute retention_time even if flush_interval is with …

### DIFF
--- a/charts/alumet/Chart.yaml
+++ b/charts/alumet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,5 +33,5 @@ dependencies:
     version: 0.7.0
     condition: alumet-relay-server.enabled
   - name: alumet-relay-client
-    version: 0.8.1
+    version: 0.8.2
     condition: alumet-relay-client.enabled

--- a/charts/alumet/charts/alumet-relay-client/Chart.yaml
+++ b/charts/alumet/charts/alumet-relay-client/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
+++ b/charts/alumet/charts/alumet-relay-client/alumet-agent.toml
@@ -103,11 +103,10 @@ ref = "cpu_energy"
 # Eg: If the metrics come from sources poll/flush every 1 second, it's recommanded to define the retention_time to at least 2 seconds.
 # This way the plugin can make use of the precedent values of this metric to make interpolations.
 {{- $val := .Values.plugins.rapl.flush_interval | toString }}
-{{- $lastChar := substr (int (sub (len $val) 1)) (int (len $val)) $val }}
-{{ $poll := trimSuffix $lastChar .Values.plugins.rapl.flush_interval | int -}}
-{{- $new_poll := add $poll 1 -}}
-
-retention_time = "{{ $new_poll }}{{ $lastChar }}"
+{{ $unit := regexReplaceAll "^[0-9]+" $val "" }}
+{{ $numeric := regexReplaceAll "[^0-9]" $val "" }}
+{{ $new_poll := add $numeric 1 -}}
+retention_time = "{{ $new_poll }}{{ $unit }}"
 
 # Timeseries related to the resources.
 [plugins.energy-attribution.formulas.attributed_rapl_energy.per_resource]
@@ -157,12 +156,11 @@ ref = "gpu_energy"
 # This need to be coherent with the poll_interval/flush_interval of the metrics involved in this formula.
 # Eg: If the metrics come from sources poll/flush every 1 second, it's recommanded to define the retention_time to at least 2 seconds.
 # This way the plugin can make use of the precedent values of this metric to make interpolations.
-{{- $val := .Values.plugins.nvml.flush_interval | toString }}
-{{- $lastChar := substr (int (sub (len $val) 1)) (int (len $val)) $val }}
-{{ $poll := trimSuffix $lastChar .Values.plugins.nvml.flush_interval | int -}}
-{{- $new_poll := add $poll 1 -}}
-
-retention_time = "{{ $new_poll }}{{ $lastChar }}"
+{{ $val := .Values.plugins.nvml.flush_interval | toString }}
+{{ $unit := regexReplaceAll "^[0-9]+" $val "" }}
+{{ $numeric := regexReplaceAll "[^0-9]" $val "" }}
+{{ $new_poll := add $numeric 1 -}}
+retention_time = "{{ $new_poll }}{{ $unit }}"
 
 [plugins.energy-attribution.formulas.attributed_nvml_energy.per_resource]
 gpu_energy = { metric = "nvml_energy_consumption", resource_kind = "gpu" }


### PR DESCRIPTION
<!-- markdownlint-disable -->
# Description
Miss one commit in previous relase (0.8.1):
The parameter retention_time (for energy_attribution plugin) is automatically compute using input parameter flush_interval.
We manage the use case: flush_interval with any units (s, m, ms, ns, ..)
All supported units are defined in the [crates](https://crates.io/crates/humantime)

- Fixes #53 

# PR check

Before merging this PR, I have verified that:

- [ ] Updated the README if needed
- [ ] Updated the values.yaml of every modified chart
- [ ] Updated the version of the modified charts in Chart.yaml
